### PR TITLE
noissue: removed fat jar generation with shadow plugin

### DIFF
--- a/alma-integrations/build.gradle
+++ b/alma-integrations/build.gradle
@@ -28,16 +28,8 @@ dependencies {
     implementation libs.apache.commons.lang3
     implementation libs.jakarta.xml.bind
 
-    //implementation platform('software.amazon.awssdk:bom:2.17.191') // Version manually specified for each module in libs.versions.toml
-    //implementation group: 'software.amazon.awssdk', name: 'secretsmanager' // Do we need this to match version?
-
     implementation project(path: ":basebibliotek-generated", configuration: 'default')
     implementation project(path: ":alma-generated", configuration: 'default')
-
-    shadowJar {
-        archiveClassifier.set('')
-        zip64 true
-    }
 }
 
 test {

--- a/basebibliotek-fetch-cronjob/build.gradle
+++ b/basebibliotek-fetch-cronjob/build.gradle
@@ -20,8 +20,4 @@ dependencies {
 
     implementation project(path: ":basebibliotek-generated", configuration: 'default')
 
-    shadowJar {
-        archiveClassifier.set('')
-        zip64 true
-    }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,10 +8,9 @@ repositories {
 
 dependencies {
     // Here we can specify versions which is not supported under plugins bracket
-    implementation group: 'nebula.lint', name: 'nebula.lint.gradle.plugin', version: '20.6.2'
-    implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.15'
-    implementation group: 'org.jacoco', name: 'org.jacoco.report', version: '0.8.15'
-    implementation group: 'com.gradleup.shadow', name: 'com.gradleup.shadow.gradle.plugin', version: '9.4.2'
+    implementation "nebula.lint:nebula.lint.gradle.plugin:20.6.2"
+    implementation "org.jacoco:org.jacoco.core:0.8.15"
+    implementation "org.jacoco:org.jacoco.report:0.8.15"
 }
 
 // How Jar files are named

--- a/buildSrc/src/main/groovy/basebibliotek.alma.integrations.core.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/basebibliotek.alma.integrations.core.java-conventions.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'com.gradleup.shadow'
     id 'nebula.lint'
     id 'jacoco-report-aggregation'
 }
@@ -44,7 +43,7 @@ subprojects {
                 }
             }
 
-            // We do not want a jar for our own modules, just a fatJar.
+            // SAM handles packaging, disable default jar task for function modules
             jar.enabled = false
         }
 }
@@ -57,11 +56,6 @@ tasks.named('test', Test) {
     testLogging {
        events 'skipped', 'failed' //, 'passed'
     }
-}
-
-// We want to compile all jars especially those from auto generated modules before building or else the build will fail
-tasks.named('build').configure {
-    dependsOn tasks.named('shadowJar')
 }
 
 tasks.named('jacocoTestReport', JacocoReport) {


### PR DESCRIPTION
it caused trouble when bumping to version 9.X, so had to downgrade.

found out while downgrading that it caused a big target and .aws-sam folder, and that I did not need it since aws sam builds artifacts itself as well. trying without and we will see if still works